### PR TITLE
Resolve issues with duplicate spawned minecarts and platforms

### DIFF
--- a/src/com/afforess/minecartmania/entity/MinecartManiaWorld.java
+++ b/src/com/afforess/minecartmania/entity/MinecartManiaWorld.java
@@ -50,47 +50,47 @@ public class MinecartManiaWorld {
 	 * @param the minecart to wrap
 	 */
 	@ThreadSafe
-	public static MMMinecart getOrCreateMMMinecart(Minecart minecart) {
+	public synchronized static MMMinecart getOrCreateMMMinecart(Minecart minecart) {
 		prune();
 		final int id = minecart.getEntityId();
 		MMMinecart testMinecart = minecarts.get(id);
 		
 		if (testMinecart == null) {
 			Logger.debug("No MM minecart found for id " + id);
-			synchronized(minecart) {
 				
-				//may have been created while waiting for the lock
-				if (minecarts.get(id) != null) {
-					return minecarts.get(id);
-				}
-				
-				if(replacedIDs.contains(id)){
-					Logger.debug("Duplication requested for " + id);
-					//special case got call for minecart we already replaced, happens when multiple events are queued for the vanilla cart.
-					for (Entry<Integer, MMMinecart> ent : minecarts.entrySet()) {
-						if(ent.getValue().oldID() == id){
-							return ent.getValue();
-						}
-					}
-					Logger.debug("Minecart " + id + " listed as replaced but no entity found!!");
-					return null;
-				}
-				
+                        //may have been created while waiting for the lock
+                        if (minecarts.get(id) != null) {
+                                return minecarts.get(id);
+                        }
 
-				MMMinecart newCart;
-				
-				if (minecart instanceof StorageMinecart) {
-					newCart = new MMStorageCart(minecart);
-				}
-				else {
-					newCart = new MMMinecart(minecart);
-				}
-				
-				minecarts.put(newCart.getEntityId(), newCart);
-				replacedIDs.add(id);
-				return newCart;
-			}
-		}
+                        if(replacedIDs.contains(id)){
+                                Logger.debug("Duplication requested for " + id);
+                                //special case got call for minecart we already replaced, happens when multiple events are queued for the vanilla cart.
+                                for (Entry<Integer, MMMinecart> ent : minecarts.entrySet()) {
+                                        if(ent.getValue().oldID() == id){
+                                                minecarts.put(ent.getValue().getEntityId(), ent.getValue());
+                                                return ent.getValue();
+                                        }
+                                }
+                                Logger.debug("Minecart " + id + " listed as replaced but no entity found!!");
+                                return null;
+                        }
+
+
+                        MMMinecart newCart;
+
+                        if (minecart instanceof StorageMinecart) {
+                                newCart = new MMStorageCart(minecart);
+                        }
+                        else {
+                                newCart = new MMMinecart(minecart);
+                        }
+
+                        minecarts.put(newCart.getEntityId(), newCart);
+                        replacedIDs.add(id);
+                        return newCart;
+                }
+		
 		
 		return testMinecart;
 	}

--- a/src/com/afforess/minecartmania/minecarts/MMMinecart.java
+++ b/src/com/afforess/minecartmania/minecarts/MMMinecart.java
@@ -1029,7 +1029,8 @@ public class MMMinecart {
 		}
 	}
 
-	protected Minecart replaceCart(Minecart m){
+        @ThreadSafe
+	protected synchronized Minecart replaceCart(Minecart m){
 		EntityMinecartAbstract mhandle = ((CraftMinecart) m).getHandle();
 
 		//check if already a mm entity.

--- a/src/com/afforess/minecartmania/signs/actions/PlatformAction.java
+++ b/src/com/afforess/minecartmania/signs/actions/PlatformAction.java
@@ -8,34 +8,39 @@ import org.bukkit.entity.LivingEntity;
 import com.afforess.minecartmania.minecarts.MMMinecart;
 import com.afforess.minecartmania.signs.SignAction;
 import com.afforess.minecartmania.utils.StringUtils;
+import java.util.HashMap;
+import org.bukkit.Location;
 
 public class PlatformAction extends SignAction {
-
+        private HashMap<Location, Long> lastPlatform = new HashMap<Location, Long>();      
 	private int range = -1;
 
 	@Override
 	public boolean execute(MMMinecart minecart) {
 		if (range <=0) return false;
-		if ( minecart.isStandardMinecart() && !minecart.hasPassenger()) {
-			List<Entity> list = minecart.getBukkitEntity().getNearbyEntities(range*2, range*2, range*2);
+                Long lastPlatform = this.lastPlatform.get(loc); //cooldown on spawner
+		if (lastPlatform == null || (Math.abs(System.currentTimeMillis() - lastPlatform) > 100)) {
+                    if ( minecart.isStandardMinecart() && !minecart.hasPassenger()) {
+                            List<Entity> list = minecart.getBukkitEntity().getNearbyEntities(range*2, range*2, range*2);
 
-			LivingEntity closest = null;
-			double distance = -1;
-			for (Entity le : list) {
-				if (le instanceof LivingEntity){
-					if (le.getLocation().toVector().distanceSquared(minecart.getLocation().toVector()) < distance || closest == null) {
-						closest = (LivingEntity) le;
-						distance = le.getLocation().toVector().distanceSquared(minecart.getLocation().toVector());
-					}
-				}
-			}
+                            LivingEntity closest = null;
+                            double distance = -1;
+                            for (Entity le : list) {
+                                    if (le instanceof LivingEntity){
+                                            if (le.getLocation().toVector().distanceSquared(minecart.getLocation().toVector()) < distance || closest == null) {
+                                                    closest = (LivingEntity) le;
+                                                    distance = le.getLocation().toVector().distanceSquared(minecart.getLocation().toVector());
+                                            }
+                                    }
+                            }
 
-			if (closest != null ) {
-				minecart.setPassenger(closest);		
-				return true;
-			}
-		}
-
+                            if (closest != null ) {
+                                    this.lastPlatform.put(loc, System.currentTimeMillis());
+                                    minecart.setPassenger(closest);		
+                                    return true;
+                            }
+                    }
+                } 
 		return false;
 	}
 


### PR DESCRIPTION
"Additional thread safety" slightly increases the scope under which synchronous operations are performed, particularly in a couple of places related to creating minecart entities.

"Add cooldown (100ms) to platforms" is an additional protection to ensure that if multiple minecarts on at the same platform at the same time, we don't enter a tight loop bouncing the player between them.

In my tests this resolves the bukkit ticket referenced here: http://dev.bukkit.org/bukkit-plugins/minecartmania-reborn/tickets/87-server-freezes-when-approaching-spawn-block-incorrectly/
